### PR TITLE
Check also the root level of a directory structure for the existence of a certain directory.

### DIFF
--- a/src/LibHelpers.cpp
+++ b/src/LibHelpers.cpp
@@ -111,11 +111,14 @@ bool LocateDirUp(const TCHAR* dirName, const TCHAR* currentDir, TCHAR* fullDirPa
 
 	_tcscpy_s(fullDirPath, fullDirPathSize, currentDir);
 
-	while (!::PathIsRoot(fullDirPath))
+	while (true)
 	{
 		::PathCombine(testPath, fullDirPath, dirName);
 		if (::PathIsDirectory(testPath))
 			return true;
+
+		if (::PathIsRoot(fullDirPath))
+			break;
 
 		// up one folder
 		::PathCombine(testPath, fullDirPath, TEXT(".."));


### PR DESCRIPTION
Check also the root level of a directory structure for the existence of a certain directory in order to find `.svn` directories that are located at the root level. Fixes #332